### PR TITLE
Fix SingleQuote Missing and Add -f

### DIFF
--- a/automation/scripts/fabric_feature_maintainance.py
+++ b/automation/scripts/fabric_feature_maintainance.py
@@ -36,10 +36,10 @@ if action == "create":
             workspace_name = feature_name.format(feature_name=branch_name_trimmed, layer_name=layer)
             workspace_name_escaped = workspace_name.replace("/", "\\/")
 
-            if fabcli.run_command(f"exists {workspace_name_escaped}.Workspace").replace("*", "").strip().lower() == "false":
+            if fabcli.run_command(f"exists '{workspace_name_escaped}.Workspace'").replace("*", "").strip().lower() == "false":
                 misc.print_info(f"Creating workspace '{workspace_name}'...", bold=True, end="")
                 fabcli.run_command(f"create '{workspace_name_escaped}.Workspace' -P capacityname={capacity_name}")
-                workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
+                workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
                 misc.print_success(" ✔", bold=True)
 
                 if permissions:
@@ -75,7 +75,7 @@ if action == "create":
                         connection_name = git_settings.get("myGitCredentials").get("connection_name").format(identity_id=identity_id, identity_username=identity_username)
                         
                         if fabcli.connection_exists(connection_name):
-                            connection_id = fabcli.run_command(f"get .connections/{connection_name}.Connection -q id")
+                            connection_id = fabcli.run_command(f"get .connections/{connection_name}.Connection -q id -f")
                             git_settings["myGitCredentials"].pop("connection_name", None) # Remove connection name
                             git_settings["myGitCredentials"]["connectionId"] = connection_id # Add connection id required by Fabric REST API
                         
@@ -99,7 +99,7 @@ if action == "create":
                 misc.print_info(f"{workspace_name} already exist. Feature workspace creation skipped!", bold=True)
                 if layer_definition.get("git_synchronize_on_commit", False):
                     misc.print_info(f"  • Synchronizing workspace {workspace_name_escaped} with latest changes from Git...", end="")
-                    workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
+                    workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
                     
                     git_status = fabcli.get_git_status(workspace_id)
 
@@ -121,7 +121,7 @@ elif action == "update": # Support workspace synchronization on commit for exist
             workspace_name_escaped = workspace_name.replace("/", "\\/")
             if layer_definition.get("git_synchronize_on_commit", False):
                 misc.print_info(f"Synchronizing workspace {workspace_name_escaped} with latest changes from Git repo...", bold=True, end="")
-                workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
+                workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
 
                 git_status = fabcli.get_git_status(workspace_id)
                 if git_status and git_status.get("workspaceHead") == git_status.get("remoteCommitHash"):
@@ -142,7 +142,7 @@ elif action == "delete":
         workspace_name = feature_name.format(feature_name=branch_name_trimmed, layer_name=layer)
         workspace_name_escaped = workspace_name.replace("/", "\\/")
         misc.print_info(f"Deleting workspace '{workspace_name}'... ", bold=True, end="")
-        if fabcli.run_command(f"exists {workspace_name_escaped}.Workspace").replace("*", "").strip().lower() == "true":
+        if fabcli.run_command(f"exists '{workspace_name_escaped}.Workspace'").replace("*", "").strip().lower() == "true":
             fabcli.run_command(f"rm '{workspace_name_escaped}.Workspace' -f")
             misc.print_success(" ✔")
         else:

--- a/automation/scripts/fabric_release.py
+++ b/automation/scripts/fabric_release.py
@@ -63,7 +63,7 @@ if env_definition:
             workspace_name = solution_name.format(layer=layer, environment=environment)
             workspace_name_escaped = workspace_name.replace("/", "\\/")
 
-            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
+            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
 
             misc.print_subheader(f"Running release to workspace {workspace_name}!")
 

--- a/automation/scripts/fabric_setup.py
+++ b/automation/scripts/fabric_setup.py
@@ -137,13 +137,13 @@ if action == "create":
             
             misc.print_info(f"Creating workspace '{workspace_name}'...", bold=True, end="")
 
-            if fabcli.run_command(f"exists {workspace_name_escaped}.Workspace").replace("*", "").strip().lower() == "false":
+            if fabcli.run_command(f"exists '{workspace_name_escaped}.Workspace'").replace("*", "").strip().lower() == "false":
                 fabcli.run_command(f"create '{workspace_name_escaped}.Workspace' -P capacityname={capacity_name}")
                 misc.print_success(" ✔", bold=True)
             else:
                 misc.print_warning(f" ⚠ Already exists", bold=True)
 
-            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
+            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
                 
             # Update layer_definition
             layer_definition["workspace_id"] = workspace_id
@@ -156,13 +156,13 @@ if action == "create":
                 for permission, definitions in permissions.items():
                     for definition in definitions:
                         misc.print_info(f"  • Assigning workspace permission for identity {definition.get('id')}...", end="")
-                        fabcli.run_command(f"acl set {workspace_name_escaped}.Workspace -I {definition.get('id')} -R {permission.lower()} -f")
+                        fabcli.run_command(f"acl set '{workspace_name_escaped}.Workspace' -I {definition.get('id')} -R {permission.lower()} -f")
                         misc.print_success(" ✔")
                 
             if (layer_definition.get("create_workspace_identity", False)):
                 misc.print_info(f"  • Creating workspace identity...", end="")
-                if fabcli.run_command(f"exists {workspace_name_escaped}.Workspace/.managedidentities/{workspace_name_escaped}.ManagedIdentity").replace("*", "").strip().lower() == "false":
-                    fabcli.run_command(f"create {workspace_name_escaped}.Workspace/.managedidentities/{workspace_name_escaped}.ManagedIdentity")
+                if fabcli.run_command(f"exists '{workspace_name_escaped}.Workspace/.managedidentities/{workspace_name_escaped}.ManagedIdentity'").replace("*", "").strip().lower() == "false":
+                    fabcli.run_command(f"create '{workspace_name_escaped}.Workspace/.managedidentities/{workspace_name_escaped}.ManagedIdentity'")
                     misc.print_success(" ✔")
                 else:
                     misc.print_warning(f" ⚠ Already exists", bold=True)      
@@ -216,12 +216,12 @@ if action == "create":
                     resource_type = misc.get_private_endpoint_resource_type(private_endpoint.get("id"))
                     print(f"    ◦ Provisioning {private_endpoint.get('name')}...", end="")
 
-                    if (fabcli.item_exists(f"{workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint")):
+                    if (fabcli.item_exists(f"'{workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint'")):
                         misc.print_warning(" ⚠ Already exists")
                     else:
                         try:
                             mpe_result = fabcli.run_command(
-                                f'create {workspace_name_escaped}.Workspace/.managedprivateendpoints/'
+                                f"create '{workspace_name_escaped}.Workspace/.managedprivateendpoints/'"
                                 f'{private_endpoint.get("name")}.ManagedPrivateEndpoint'
                                 f' -P targetPrivateLinkResourceId={private_endpoint.get("id")},targetSubresourceType={resource_type},'
                                 f'autoApproveEnabled=true' if private_endpoint.get("auto_approve") else 'autoApproveEnabled=false'
@@ -347,12 +347,12 @@ elif action == "delete":
         workspace_name = solution_name.format(layer=layer, environment=environment)
         workspace_name_escaped = workspace_name.replace("/", "\\/")
         misc.print_info(f"Deleting workspace '{workspace_name}'...", bold=True, end="")
-        if fabcli.run_command(f"exists {workspace_name_escaped}.Workspace").replace("*", "").strip().lower() == "true":
+        if fabcli.run_command(f"exists '{workspace_name_escaped}.Workspace'").replace("*", "").strip().lower() == "true":
 
             if layer_definition.get("private_endpoints"):
                 for private_endpoint in layer_definition.get("private_endpoints"):
-                    if (fabcli.item_exists(f"{workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint")):
-                        fabcli.run_command(f"rm {workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint -f")
+                    if (fabcli.item_exists(f"'{workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint'")):
+                        fabcli.run_command(f"rm '{workspace_name_escaped}.Workspace/.managedprivateendpoints/{private_endpoint.get('name')}.ManagedPrivateEndpoint' -f")
 
             fabcli.run_command(f"rm '{workspace_name_escaped}.Workspace' -f")
             misc.print_success(" ✔")

--- a/automation/scripts/fabric_setup.py
+++ b/automation/scripts/fabric_setup.py
@@ -33,6 +33,7 @@ action = args.action.lower()
 
 # Authenticate
 fabcli.run_command("config set encryption_fallback_enabled true")
+fabcli.run_command("config set folder_listing_enabled true")
 fabcli.run_command(f"auth login -u {client_id} -p {client_secret} --tenant {tenant_id}")
 
 # Load JSON environment files (main and environment specific) and merge
@@ -171,7 +172,7 @@ if action == "create":
                 print_item_header = True
                 for item_type, items in layer_definition.get("items").items():
                     for item in items:
-                        if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase"}:
+                        if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase", "Warehouse"}:
                             has_item_connections = True
 
                         if not item.get("skip_item_creation", False):
@@ -179,11 +180,11 @@ if action == "create":
                                 print(f"  • Creating workspace items:") 
                                 print_item_header = False
 
-                            misc.print_info(f"    ◦ {item_type}: {item.get("item_name")}...", end="")
-
-                            if not fabcli.item_exists(f'{workspace_name_escaped}.Workspace/{item.get("item_name")}.{item_type}'):    
-                                fabcli.run_command(f"create '{workspace_name_escaped}.Workspace/{item.get("item_name")}.{item_type}'")
-                                item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item.get('item_name')}.{item_type}", retry_count=2)
+                            item_folder = f'{item.get("item_folder")}/' if item.get("item_folder") else ""
+                            misc.print_info(f"    ◦ {item_type}: {item_folder}{item.get("item_name")}...", end="")
+                            if not fabcli.item_exists(f'{workspace_name_escaped}.Workspace/{item_folder}{item.get("item_name")}.{item_type}'):    
+                                fabcli.run_command(f"create '{workspace_name_escaped}.Workspace/{item_folder}{item.get("item_name")}.{item_type}'")
+                                item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item_folder}{item.get('item_name')}.{item_type}", retry_count=2)
                                 
                                 if item_type in {"Lakehouse"}: 
                                     # Wait until SQL endpoint provisioning completes; treat missing metadata as still provisioning
@@ -200,14 +201,14 @@ if action == "create":
                                             break
                                         print(".", end="")
                                         time.sleep(2)
-                                        item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item.get('item_name')}.{item_type}")
+                                        item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item_folder}{item.get('item_name')}.{item_type}")
 
                                 if item["item_metadata"]:                           
                                     misc.print_success(" ✔")
                                 else:
                                     misc.print_error(" ✖ Failed!")
                             else:
-                                item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item.get('item_name')}.{item_type}")
+                                item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item_folder}{item.get('item_name')}.{item_type}")
                                 misc.print_warning(f" ⚠ Already exists")
   
             if layer_definition.get("private_endpoints"):
@@ -243,7 +244,7 @@ if action == "create":
                     git_settings = env_definition.get("generic").get("git_settings")
                     git_settings["gitProviderDetails"]["directoryName"] = layer_definition.get("git_directoryName")                    
                 
-                    if git_connection.get("id"):                   
+                    if git_connection.get("id"):
                         connect_response = fabcli.connect_workspace_to_git(workspace_id, git_settings)
                         if connect_response:                            
                             init_response = fabcli.initialize_git_connection(workspace_id)
@@ -269,7 +270,7 @@ if action == "create":
                     for item_type, items in layer_definition.get("items").items():
                         for item in items:
 
-                            if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase"}:
+                            if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase", "Warehouse"}:
                                 connection_name = item.get("connection_name").format(layer=layer, environment=environment)
                                 item["item_metadata"] = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item.get('item_name')}.{item_type}")
                                 
@@ -278,11 +279,12 @@ if action == "create":
                                 if item["item_metadata"]:
                                     server = (
                                         item.get("item_metadata").get("properties").get("sqlEndpointProperties").get("connectionString") if item_type == "Lakehouse" else
-                                        item.get("item_metadata").get("properties").get("serverFqdn") 
+                                        item.get("item_metadata").get("properties").get("serverFqdn") if item_type == "SQLDatabase" else
+                                        item.get("item_metadata").get("properties").get("connectionString")  
                                     )
 
                                     database = (
-                                        item.get("item_name") if item_type == "Lakehouse" else
+                                        item.get("item_name") if item_type in ("Lakehouse","Warehouse") else
                                         item.get("item_metadata").get("properties").get("databaseName") 
                                     )
 
@@ -362,7 +364,7 @@ elif action == "delete":
         if layer_definition.get("items"):
             for item_type, items in layer_definition.get("items").items():
                 for item in items:    
-                    if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase"}:
+                    if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase", "Warehouse"}:
                         connection_name = item.get("connection_name").format(layer=layer, environment=environment)
                         misc.print_info(f"  • Deleting connection '{connection_name}'... ", bold=False, end="")
                         if fabcli.run_command(f"exists .connections/{connection_name}.Connection").replace("*", "").strip().lower() == "true":

--- a/automation/scripts/generate_connection_string.py
+++ b/automation/scripts/generate_connection_string.py
@@ -35,21 +35,22 @@ env_definition = misc.merge_json(main_json, env_json)
 
 solution_name = env_definition.get("name")
 workspace_name = solution_name.format(layer=layer, environment=environment)
-workspace_name_escaped = workspace_name.replace("/", "\\/")
-sqldb_item = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{database}.SQLDatabase")
 
-# Example: You may want to adjust the server/database names per environment
-server = sqldb_item.get('properties').get('serverFqdn')
-database = sqldb_item.get("properties").get("databaseName")
+item_type = None
+for env_item_type in env_definition.get("layers").get(layer).get("items"):
+    if env_item_type in ["Warehouse","SQLDatabase"]:
+        for item in env_definition.get("layers").get(layer).get("items").get(env_item_type):
+            item_name = item.get("item_name")
+            if item_name == database:
+                item_type = env_item_type
+                break 
 
-connection_string = (
-    f"Server={server};"
-    f"Database={database};"
-    f"Authentication=Active Directory Service Principal;"
-    f"User Id={client_id};"
-    f"Password={client_secret};"
-    f"Encrypt=True;"
-    f"Connection Timeout=60;"
+connection_string = fabcli.generate_connection_string(
+    workspace_name=workspace_name,
+    item_type=item_type,
+    database=database,
+    client_id=client_id,
+    client_secret=client_secret
 )
 
 with open(args.output_file, "w") as f:

--- a/automation/scripts/locale/locale_build_parameter_file.py
+++ b/automation/scripts/locale/locale_build_parameter_file.py
@@ -22,7 +22,7 @@ args = ["--environments", environments,
         "--client_secret", env_credentials.get("client_secret")
         ]
 
-process = subprocess.Popen(['python', '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
+process = subprocess.Popen([sys.executable, '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
 
 # Print the output line by line as it is generated
 for line in process.stdout:

--- a/automation/scripts/locale/locale_maintain_feature.py
+++ b/automation/scripts/locale/locale_maintain_feature.py
@@ -23,7 +23,7 @@ args = ["--tenant_id", env_credentials.get("tenant_id"),
         "--action", action,
         "--branch_name", branch_name]
 
-process = subprocess.Popen(['python', '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
+process = subprocess.Popen([sys.executable, '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
 
 # Print the output line by line as it is generated
 for line in process.stdout:

--- a/automation/scripts/locale/locale_release.py
+++ b/automation/scripts/locale/locale_release.py
@@ -28,7 +28,7 @@ for environment in environments:
             "--client_secret", env_credentials.get("client_secret")
             ]
 
-    process = subprocess.Popen(['python', '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, encoding='utf-8')
+    process = subprocess.Popen([sys.executable, '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, encoding='utf-8')
 
     # Print output live
     for line in process.stdout:

--- a/automation/scripts/locale/locale_setup.py
+++ b/automation/scripts/locale/locale_setup.py
@@ -26,7 +26,7 @@ for environment in environments:
             "--github_pat", env_credentials.get("github_pat")
             ]
 
-    process = subprocess.Popen(['python', '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
+    process = subprocess.Popen([sys.executable, '-u', script_path] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, encoding='utf-8')
 
     # Print the output line by line as it is generated
     for line in process.stdout:

--- a/automation/scripts/modules/fabric_cli_functions.py
+++ b/automation/scripts/modules/fabric_cli_functions.py
@@ -252,3 +252,28 @@ def poll_operation_status(operation_id):
             return None
     
     return None  # Operation timed out or failed
+
+def generate_connection_string(workspace_name, item_type, database, client_id, client_secret):
+    print(f"Generating connection string for {item_type} '{database}' in workspace '{workspace_name}'...")
+    workspace_name_escaped = workspace_name.replace("/", "\\/")
+    sqldb_item = get_item(f"/{workspace_name_escaped}.Workspace/{database}.{item_type}")
+    print(sqldb_item)
+    if item_type == "SQLDatabase":
+        server = sqldb_item.get('properties').get('serverFqdn')
+        database = sqldb_item.get("properties").get("databaseName")
+    elif item_type == "Lakehouse":
+        server = sqldb_item.get("properties").get('sqlEndpointProperties').get('connectionString')  
+    else:
+        server = sqldb_item.get('properties').get('connectionString')
+
+    connection_string = (
+        f"Server={server};"
+        f"Database={database};"
+        f"Authentication=Active Directory Service Principal;"
+        f"User Id={client_id};"
+        f"Password={client_secret};"
+        f"Encrypt=True;"
+        f"Connection Timeout=60;"
+    )
+
+    return connection_string

--- a/automation/scripts/utils_build_parameter_file.py
+++ b/automation/scripts/utils_build_parameter_file.py
@@ -53,8 +53,10 @@ for environment in environments:
         for layer_name, layer_definition in layers.items():
             workspace_name = solution_name.format(layer=layer_name, environment=environment)
             workspace_name_escaped = workspace_name.replace("/", "\\/")
-            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id").strip()
-            print(f"Getting data for {workspace_id}, {workspace_name}")
+            workspace_id = fabcli.run_command(f"get '{workspace_name_escaped}.Workspace' -q id -f").strip()
+            
+            # misc.print_info(f"Getting data for {workspace_id}, {workspace_name}...", bold=True)
+            
             if(misc.is_guid(workspace_id)):
                 workspace_items = fabcli.list_all_workspace_items(workspace_id)
 

--- a/automation/scripts/utils_build_parameter_file.py
+++ b/automation/scripts/utils_build_parameter_file.py
@@ -74,11 +74,11 @@ for environment in environments:
                         "type": item.get("type")
                     }
 
-                    if item.get("type") in {"Lakehouse", "SQLDatabase"}:
+                    if item.get("type") in {"Lakehouse", "SQLDatabase", "Warehouse"}:
                         item_details = fabcli.get_item(f"/{workspace_name_escaped}.Workspace/{item.get('displayName')}.{item.get('type')}", retry_count=2)
                         fabric_item.update({
-                            "connectionString": item_details.get("properties").get("connectionString") if item.get("type") == "SQLDatabase" else item_details.get("properties").get("sqlEndpointProperties").get("connectionString") ,
-                            "databaseName": item_details.get("properties").get("databaseName") if item.get("type") == "SQLDatabase" else None,
+                            "connectionString": item_details.get("properties").get("connectionString") if item.get("type") != "Lakehouse" else item_details.get("properties").get("sqlEndpointProperties").get("connectionString") ,
+                            "databaseName": item_details.get("properties").get("databaseName") if item.get("type") == "SQLDatabase" else item_details.get("displayName") if item.get("type") == "Warehouse" else None,
                             "serverFqdn": item_details.get("properties").get("serverFqdn") if item.get("type") == "SQLDatabase" else None,
                             "sqlEndpointId": item_details.get("properties").get("sqlEndpointProperties").get("id") if item.get("type") == "Lakehouse" else None,
                         })
@@ -89,7 +89,7 @@ for environment in environments:
                 if layer_definition.get("items"):
                     for item_type, items in layer_definition.get("items").items():
                         for item in items: 
-                            if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase"}:
+                            if item.get("connection_name") and item_type in {"Lakehouse", "SQLDatabase", "Warehouse"}:
                                 connection_name = item.get("connection_name").format(layer=layer_name, environment=environment)
                                 if fabcli.connection_exists(connection_name):
                                     connection = fabcli.get_item(f".connections/{connection_name}.Connection")


### PR DESCRIPTION
When a workspace contained spaces, the ADO pipeline would hang. Added single quotes when necessary.

Also on a few fab cli command added -f (force) to bypass interaction. For example : "Item definition is retrieved without its sensitivity label. Are you sure? (Y/n)"